### PR TITLE
Remove wrapper script flags that no longer exist

### DIFF
--- a/chromium-browser.sh
+++ b/chromium-browser.sh
@@ -35,17 +35,10 @@ export GNOME_DISABLE_CRASH_DIALOG=SET_BY_GOOGLE_CHROME
 [[ -f /etc/chromium/chromium.conf ]] && . /etc/chromium/chromium.conf
 CHROMIUM_FLAGS=${CHROMIUM_USER_FLAGS:-$CHROMIUM_FLAGS}
 
-CHROMIUM_DISTRO_FLAGS=" --enable-plugins \
-                        --enable-extensions \
-                        --enable-user-scripts \
-                        --enable-printing \
-                        --enable-sync \
-                        --auto-ssl-client-auth @@EXTRA_FLAGS@@"
-
 # Sanitize std{in,out,err} because they'll be shared with untrusted child
 # processes (http://crbug.com/376567).
 exec < /dev/null
 exec > >(exec cat)
 exec 2> >(exec cat >&2)
 
-exec -a "$0" "$HERE/@@CHROMIUM_BROWSER_CHANNEL@@" $CHROMIUM_FLAGS $CHROMIUM_DISTRO_FLAGS "$@"
+exec -a "$0" "$HERE/@@CHROMIUM_BROWSER_CHANNEL@@" $CHROMIUM_FLAGS "$@"

--- a/chromium.spec
+++ b/chromium.spec
@@ -1497,14 +1497,6 @@ sed -i "s|@@BUILD_TARGET@@|$BUILD_TARGET|g" %{buildroot}%{chromium_path}/%{chrom
 sed -i "s|@@CHROMIUM_PATH@@|$CHROMIUM_PATH|g" %{buildroot}%{chromium_path}/%{chromium_browser_channel}.sh
 sed -i "s|@@CHROMIUM_BROWSER_CHANNEL@@|$CHROMIUM_BROWSER_CHANNEL|g" %{buildroot}%{chromium_path}/%{chromium_browser_channel}.sh
 
-%if "%{chromium_channel}" == "%{nil}"
-	sed -i "s|@@EXTRA_FLAGS@@||g" %{buildroot}%{chromium_path}/%{chromium_browser_channel}.sh
-%else
-	# Enable debug outputs for beta and dev channels
-	export EXTRA_FLAGS="--enable-logging=stderr --v=2"
-	sed -i "s|@@EXTRA_FLAGS@@|$EXTRA_FLAGS|g" %{buildroot}%{chromium_path}/%{chromium_browser_channel}.sh
-%endif
-
 ln -s ../..%{chromium_path}/%{chromium_browser_channel}.sh %{buildroot}%{_bindir}/%{chromium_browser_channel}
 mkdir -p %{buildroot}%{_mandir}/man1/
 


### PR DESCRIPTION
None of the flags included currently exist. Even if they did, their behavior may be undesireable by default. Flag overrides should go in `chromium.conf` anyway.
